### PR TITLE
Refactor authzzie api for ckan ext

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,4 @@
 [settings]
+line_length = 120
 known_first_party = ckanext.authz_service
 known_third_party = ckan

--- a/README.md
+++ b/README.md
@@ -244,8 +244,21 @@ Defaults to `False`.
 #### `ckanext.authz_service.jwt_include_token_id` (Boolean)
 
 Whether to include a unique ID as the JWT `jti` claim. Useful if consumers
-want to ensure a token has not been replayed. 
+want to ensure a token has not been replayed.
 Defaults to `False`.
+
+Adding Authorization Bindings in CKAN extensions
+------------------------------------------------
+`ckanext-authz-service` allows other CKAN extensions to modify the default
+authorization logic for different entities as well as register authorization
+rules for new entity types.
+
+This can be done by implementing the `IAuthorizationBindings` extension
+interface.
+
+**TBD**
+
+For now see `ckanext.authz_service.plugin` for an example on how to use.
 
 Developer installation
 ----------------------

--- a/ckanext/authz_service/actions.py
+++ b/ckanext/authz_service/actions.py
@@ -12,13 +12,12 @@ from six import string_types
 from six.moves import range
 
 from . import util
-from .authz_binding import authzzie
 from .authzzie import Scope, UnknownEntityType
 
 DEFAULT_MAX_LIFETIME = 900
 
 
-def authorize(context, data_dict):
+def authorize(authorizer, context, data_dict):
     """Request an authorization token for a list of scopes
     """
     scopes = toolkit.get_or_bust(data_dict, 'scopes')
@@ -31,7 +30,7 @@ def authorize(context, data_dict):
     expires = datetime.now(tz=pytz.utc) + timedelta(seconds=lifetime)
 
     try:
-        granted_scopes = map(str, filter(None, (authzzie.check_scope(s) for s in requested_scopes)))
+        granted_scopes = map(str, filter(None, (authorizer.check_scope(s) for s in requested_scopes)))
     except UnknownEntityType as e:
         raise toolkit.ValidationError(str(e))
 

--- a/ckanext/authz_service/authz_binding/__init__.py
+++ b/ckanext/authz_service/authz_binding/__init__.py
@@ -1,5 +1,29 @@
-# We need to import the following modules to bind authorization functions
-from . import dataset, organization, resource  # noqa: F401
-from .common import authzzie
+from ..authzzie import Authzzie
+from . import dataset as ds
+from . import organization as org
+from . import resource as res
 
-__all__ = ['authzzie']
+__all__ = ['default_authz_bindings']
+
+
+def default_authz_bindings(authorizer):
+    # type: (Authzzie) -> None
+    """Initialize default authorization bindings for CKAN entities
+    """
+
+    # Register organization authz bindings
+    authorizer.register_scope_normalizer('org', org.normalize_org_scope)
+    authorizer.register_authorizer('org', org.check_org_permissions,
+                                   actions=org.ORG_ENTITY_CHECKS.keys() + [None])
+
+    # Register dataset authz bindings
+    authorizer.register_id_parser('ds', ds.dataset_id_parser)
+    authorizer.register_authorizer('ds', ds.check_dataset_permissions,
+                                   actions=ds.DS_ENTITY_CHECKS.keys() + [None],
+                                   subscopes=(None, 'data', 'metadata'))
+
+    # Register resource authz bindings
+    authorizer.register_id_parser('res', res.resource_id_parser)
+    authorizer.register_authorizer('res', res.check_resource_permissions,
+                                   actions=res.RES_ENTITY_CHECKS.keys() + [None],
+                                   subscopes=(None, 'data', 'metadata'))

--- a/ckanext/authz_service/authz_binding/common.py
+++ b/ckanext/authz_service/authz_binding/common.py
@@ -6,10 +6,6 @@ from ckan.common import g
 from ckan.plugins import toolkit
 from six import iteritems
 
-from ..authzzie import Authzzie
-
-authzzie = Authzzie()
-
 
 def normalize_id_part(id_part):
     # type: (str) -> Optional[str]

--- a/ckanext/authz_service/authz_binding/dataset.py
+++ b/ckanext/authz_service/authz_binding/dataset.py
@@ -3,8 +3,7 @@ from typing import Dict, Optional, Set
 from ckan.plugins import toolkit
 
 from . import common as c
-from .common import (authzzie, check_entity_permissions, ckan_auth_check,
-                     ckan_get_user_role_in_group, ckan_is_sysadmin,
+from .common import (check_entity_permissions, ckan_auth_check, ckan_get_user_role_in_group, ckan_is_sysadmin,
                      normalize_id_part)
 
 DS_ENTITY_CHECKS = {"read": "package_show",
@@ -16,7 +15,6 @@ DS_ENTITY_CHECKS = {"read": "package_show",
                     "purge": "dataset_purge"}
 
 
-@authzzie.authorizer('ds', actions=DS_ENTITY_CHECKS.keys() + [None], subscopes=(None, 'data', 'metadata'))
 def check_dataset_permissions(id, organization_id=None):
     """Check what dataset permissions a user has
     """
@@ -79,7 +77,6 @@ def _check_dataset_permissions_unknown_ds(id, organization_id):
     return granted
 
 
-@authzzie.id_parser('ds')
 def dataset_id_parser(id):
     # type: (str) -> Dict[str, Optional[str]]
     """ID parser for dataset entities

--- a/ckanext/authz_service/authz_binding/organization.py
+++ b/ckanext/authz_service/authz_binding/organization.py
@@ -3,8 +3,7 @@
 from typing import Optional, Set
 
 from ..authzzie import Scope
-from .common import (authzzie, check_entity_permissions, ckan_auth_check,
-                     ckan_is_sysadmin)
+from .common import check_entity_permissions, ckan_auth_check, ckan_is_sysadmin
 
 ORG_ENTITY_CHECKS = {"read": "organization_show",
                      "list": None,
@@ -15,7 +14,6 @@ ORG_ENTITY_CHECKS = {"read": "organization_show",
                      "purge": "organization_purge"}
 
 
-@authzzie.authorizer('org', actions=ORG_ENTITY_CHECKS.keys() + [None])
 def check_org_permissions(id):
     # type: (str, Optional[str]) -> Set[str]
     """Check what org permissions a user has
@@ -42,8 +40,7 @@ def check_org_permissions(id):
     return granted
 
 
-@authzzie.scope_normalizer('org')
-def normalize_org_scope(requested, granted, *_, **__):
+def normalize_org_scope(requested, granted):
     # type: (Scope, Scope) -> Scope
     """Normalize an org granted scope
     """

--- a/ckanext/authz_service/authz_binding/resource.py
+++ b/ckanext/authz_service/authz_binding/resource.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from .common import authzzie, normalize_id_part
+from .common import normalize_id_part
 from .dataset import check_dataset_permissions
 
 RES_ENTITY_CHECKS = {"read": "resource_show",
@@ -9,7 +9,6 @@ RES_ENTITY_CHECKS = {"read": "resource_show",
                      "delete": "resource_delete"}
 
 
-@authzzie.authorizer('res', actions=RES_ENTITY_CHECKS.keys() + [None], subscopes=(None, 'data', 'metadata'))
 def check_resource_permissions(id, dataset_id=None, organization_id=None):
     """Check what resource permissions a user has
     """
@@ -21,7 +20,6 @@ def check_resource_permissions(id, dataset_id=None, organization_id=None):
     return set()
 
 
-@authzzie.id_parser('res')
 def resource_id_parser(id):
     # type: (str) -> Dict[str, Optional[str]]
     """ID parser for resource entities

--- a/ckanext/authz_service/interfaces.py
+++ b/ckanext/authz_service/interfaces.py
@@ -1,0 +1,16 @@
+"""CKAN plugin interface
+"""
+from ckan.plugins import Interface
+
+from .authzzie import Authzzie
+
+
+class IAuthorizationBindings(Interface):
+
+    """A CKAN plugin interface for providing new authorization
+    bindings or overriding existing ones
+    """
+
+    def register_authz_bindings(self, authorizer):
+        # type: (Authzzie) -> None
+        pass

--- a/ckanext/authz_service/plugin.py
+++ b/ckanext/authz_service/plugin.py
@@ -1,14 +1,33 @@
+from functools import partial
+
 import ckan.plugins as plugins
 
 from ckanext.authz_service import actions
+from ckanext.authz_service.authz_binding import default_authz_bindings
+from ckanext.authz_service.authzzie import Authzzie
+from ckanext.authz_service.interfaces import IAuthorizationBindings
 
 
 class AuthzServicePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IActions)
+    plugins.implements(IAuthorizationBindings)
 
     # IActions
 
     def get_actions(self):
-        return {'authz_authorize': actions.authorize,
+        authorizer = init_authorizer()
+        return {'authz_authorize': partial(actions.authorize, authorizer),
                 'authz_verify': actions.verify,
                 'authz_public_key': actions.public_key}
+
+    def register_authz_bindings(self, authorizer):
+        default_authz_bindings(authorizer)
+
+
+def init_authorizer():
+    authorizer = Authzzie()
+    for plugin in plugins.PluginImplementations(IAuthorizationBindings):
+        if hasattr(plugin, 'register_authz_bindings'):
+            plugin.register_authz_bindings(authorizer)
+
+    return authorizer

--- a/ckanext/authz_service/tests/test_authorization.py
+++ b/ckanext/authz_service/tests/test_authorization.py
@@ -1,7 +1,7 @@
 from ckan.tests import factories, helpers
 
-from ckanext.authz_service.authz_binding import authzzie
 from ckanext.authz_service.authzzie import Scope
+from ckanext.authz_service.plugin import init_authorizer
 
 from . import FunctionalTestBase, user_context
 
@@ -24,12 +24,14 @@ class TestDatasetAuthBinding(FunctionalTestBase):
             ]
         )
 
+        self.az = init_authorizer()
+
     def test_org_member_can_read_all_datasets(self):
         """Test that org member gets 'read' authorized for the entire org
         """
         scope = Scope('ds', '{}/*'.format(self.org['name']), 'read')
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'read'}
 
     def test_org_member_cannot_write_all_datasets(self):
@@ -37,7 +39,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         """
         scope = Scope('ds', '{}/*'.format(self.org['name']), 'update')
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
     def test_non_member_cannot_read_all_datasets(self):
@@ -46,7 +48,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         scope = Scope('ds', '{}/*'.format(self.org['name']), 'read')
         user = factories.User()
         with user_context(user):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
     def test_org_admin_can_update_all_datasets(self):
@@ -54,7 +56,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         """
         scope = Scope('ds', '{}/*'.format(self.org['name']), 'update')
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'update'}
 
     def test_org_admin_can_patch_all_datasets(self):
@@ -62,7 +64,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         """
         scope = Scope('ds', '{}/*'.format(self.org['name']), 'create')
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'create'}
 
     def test_org_member_global_dataset_actions(self):
@@ -70,7 +72,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         """
         scope = Scope('ds', '{}/'.format(self.org['name']))
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'list'}
 
     def test_org_admin_global_dataset_actions(self):
@@ -78,7 +80,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         """
         scope = Scope('ds', '{}/'.format(self.org['name']))
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'create', 'list'}
 
 
@@ -102,12 +104,14 @@ class TestResourceAuthBinding(FunctionalTestBase):
 
         self.dataset = factories.Dataset(owner_org=self.org['id'])
 
+        self.az = init_authorizer()
+
     def test_org_member_can_read_all_resources(self):
         """Test that org member gets 'read' authorized for all resources of an org owned dataset
         """
         scope = Scope('res', '{}/{}/*'.format(self.org['name'], self.dataset['name']), 'read')
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'read'}
 
     def test_org_admin_can_write_all_resources(self):
@@ -115,7 +119,7 @@ class TestResourceAuthBinding(FunctionalTestBase):
         """
         scope = Scope('res', '{}/{}/*'.format(self.org['name'], self.dataset['name']), ['update', 'create'])
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'update'}
 
     def test_non_member_can_read_resources(self):
@@ -124,7 +128,7 @@ class TestResourceAuthBinding(FunctionalTestBase):
         user = factories.User()
         scope = Scope('res', '{}/{}/*'.format(self.org['name'], self.dataset['name']), ['read'])
         with user_context(user):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'read'}
 
     def test_non_member_cannot_read_private_resources(self):
@@ -134,7 +138,7 @@ class TestResourceAuthBinding(FunctionalTestBase):
         ds = factories.Dataset(owner_org=self.org['id'], private=True)
         scope = Scope('res', '{}/{}/*'.format(self.org['name'], ds['name']), ['read'])
         with user_context(user):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
     def test_non_member_cannot_write_resources(self):
@@ -143,7 +147,7 @@ class TestResourceAuthBinding(FunctionalTestBase):
         user = factories.User()
         scope = Scope('res', '{}/{}/*'.format(self.org['name'], self.dataset['name']), ['update', 'patch', 'delete'])
         with user_context(user):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
 
@@ -168,12 +172,14 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
         self.other_org = factories.Organization()
         self.sysadmin = factories.Sysadmin()
 
+        self.az = init_authorizer()
+
     def test_org_member_can_read_org(self):
         """Test that org member gets 'read' authorized for the entire org
         """
         scope = Scope('org', self.org['name'], 'read')
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'read'}
 
     def test_org_member_cannot_update_org(self):
@@ -181,7 +187,7 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
         """
         scope = Scope('org', self.org['name'], 'update')
         with user_context(self.org_member):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
     def test_org_admin_can_update_org(self):
@@ -189,7 +195,7 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
         """
         scope = Scope('org', self.org['name'], 'update')
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'update'}
 
     def test_org_admin_cannot_update_other_org(self):
@@ -197,7 +203,7 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
         """
         scope = Scope('org', self.other_org['name'], 'update')
         with user_context(self.org_admin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == set()
 
     def test_org_admin_cannot_create_new_orgs(self):
@@ -210,12 +216,12 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
 
         with helpers.changed_config('ckan.auth.user_create_organizations', False):
             with user_context(self.org_admin):
-                granted = authzzie.get_permissions(scope)
+                granted = self.az.get_permissions(scope)
             assert granted == {'list'}
 
         with helpers.changed_config('ckan.auth.user_create_organizations', True):
             with user_context(self.org_admin):
-                granted = authzzie.get_permissions(scope)
+                granted = self.az.get_permissions(scope)
             assert granted == {'list', 'create'}
 
     def test_sysadmin_can_create_new_orgs(self):
@@ -223,5 +229,5 @@ class TestOrganizationAuthBinding(FunctionalTestBase):
         """
         scope = Scope('org', actions=['create', 'list'])
         with user_context(self.sysadmin):
-            granted = authzzie.get_permissions(scope)
+            granted = self.az.get_permissions(scope)
         assert granted == {'create', 'list'}

--- a/ckanext/authz_service/tests/test_authzzie.py
+++ b/ckanext/authz_service/tests/test_authzzie.py
@@ -1,6 +1,5 @@
 """Tests for the Authzzie permission mapping library
 """
-# from nose.tools import assert_raises
 from parameterized import parameterized
 from six import iteritems
 
@@ -48,11 +47,12 @@ class TestAuthzzieScope(object):
 class TestAuthzzie(object):
 
     def test_authzzie_non_bound_action_not_granted(self):
-        az = authzzie.Authzzie()
 
-        @az.authorizer('foo', {'read', 'write'})
         def test_authorizer(_):
             return set()
+
+        az = authzzie.Authzzie()
+        az.register_authorizer('foo', test_authorizer, {'read', 'write'})
 
         scope = authzzie.Scope('foo', 'entity-01', {'delete'})
         granted = az.get_permissions(scope)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.1',
+    version='0.1.0',
 
     description='''Add CKAN API to generate JWT tokens with authorization information''',
     long_description=long_description,


### PR DESCRIPTION
This closes #9 .

Replaced the decorator API with more straight-forward registration functions, and added a CKAN extension interface. 