### PR TITLE
Refactor tests to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ docs/_build/
 
 # Make sentinel files
 /.make-status/
+
+# Development environment
+/ckan/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ language: python
 services:
   - postgresql
   - redis
+  - docker
 
 # use an older trusty image, because the newer images cause build errors with
 # psycopg2 that comes with CKAN<2.8:
 #   "Error: could not determine PostgreSQL version from '10.1'"
 # see https://github.com/travis-ci/travis-ci/issues/8897
-dist: trusty
-group: deprecated-2017Q4
+#dist: trusty
+#group: deprecated-2017Q4
 
 python:
   - 2.7
@@ -18,6 +19,10 @@ python:
 env:
   - CKANVERSION=master
   - CKANVERSION=2.8
+
+before_install:
+  - docker pull ckan/solr
+  - docker run -d -p 8983:8983 -e CKAN_SOLR_PASSWORD=ckan ckan/solr
 
 install:
   - bash bin/travis-build.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ env:
 install:
   - bash bin/travis-build.bash
   - pip install coveralls
+  - make develop CKAN_PATH=./ckan
 
-script: make coverage CKAN_PATH=./ckan
+script: make test CKAN_PATH=./ckan WITH_COVERAGE=1
 
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for ckanext-versions
+# Makefile for ckanext-authz-service
 
 PACKAGE_DIR := ckanext/authz_service
 PACKAGE_NAME := ckanext.authz_service
@@ -7,20 +7,58 @@ SHELL := bash
 PYTHON := python
 PIP := pip
 PIP_COMPILE := pip-compile
-PASTER := paster
 PYTEST := pytest
-
-# The `ckan` command line only exists in newer versions of CKAN
-CKAN_CLI := $(shell which ckan | head -n1)
+PASTER := paster
+DOCKER_COMPOSE := docker-compose
+GIT := git
 
 # Find GNU sed in path (on OS X gsed should be preferred)
 SED := $(shell which gsed sed | head -n1)
 
+# The `ckan` command line only exists in newer versions of CKAN
+CKAN_CLI := $(shell which ckan | head -n1)
+
 TEST_INI_PATH := ./test.ini
-CKAN_PATH := ../ckan
 SENTINELS := .make-status
 
 PYTHON_VERSION := $(shell $(PYTHON) -c 'import sys; print(sys.version_info[0])')
+
+# CKAN environment variables
+CKAN_PATH := ckan
+CKAN_REPO_URL := https://github.com/ckan/ckan.git
+CKAN_VERSION := ckan-2.8.3
+CKAN_CONFIG_FILE := $(CKAN_PATH)/development.ini
+CKAN_SITE_URL := http://localhost:5000
+POSTGRES_USER := ckan
+POSTGRES_PASSWORD := ckan
+POSTGRES_DB := ckan
+CKAN_SOLR_PASSWORD := ckan
+DATASTORE_DB_NAME := datastore
+DATASTORE_DB_RO_USER := datastore_ro
+DATASTORE_DB_RO_PASSWORD := datastore_ro
+CKAN_LOAD_PLUGINS := authz_service stats text_view image_view recline_view datastore
+
+CKAN_CONFIG_VALUES := \
+		ckan.site_url=$(CKAN_SITE_URL) \
+		sqlalchemy.url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(POSTGRES_DB) \
+		ckan.datastore.write_url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(DATASTORE_DB_NAME) \
+		ckan.datastore.read_url=postgresql://$(DATASTORE_DB_RO_USER):$(DATASTORE_DB_RO_PASSWORD)@localhost/$(DATASTORE_DB_NAME) \
+		ckan.plugins='$(CKAN_LOAD_PLUGINS)' \
+		ckan.storage_path='%(here)s/storage' \
+		solr_url=http://127.0.0.1:8983/solr/ckan \
+		ckanext.authz_service.jwt_algorithm=HS256 \
+		ckanext.authz_service.jwt_private_key=this-is-a-test-only-key
+
+CKAN_TEST_CONFIG_VALUES := \
+		sqlalchemy.url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(POSTGRES_DB)_test \
+		ckan.datastore.write_url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(DATASTORE_DB_NAME)_test \
+		ckan.datastore.read_url=postgresql://$(DATASTORE_DB_RO_USER):$(DATASTORE_DB_RO_PASSWORD)@localhost/$(DATASTORE_DB_NAME)_test
+
+ifdef WITH_COVERAGE
+  COVERAGE_ARG := --cov=$(PACKAGE_NAME)
+else
+  COVERAGE_ARG :=
+endif
 
 
 dev-requirements.%.txt: dev-requirements.in
@@ -29,11 +67,137 @@ dev-requirements.%.txt: dev-requirements.in
 requirements.%.txt: requirements.in
 	$(PIP_COMPILE) --no-index requirements.in -o $@
 
+## Update requirements files for the current Python version
+requirements: $(SENTINELS)/requirements
+.PHONEY: requirements
+
+## Install this extension to the current Python environment
+install: $(SENTINELS)/install
+.PHONY: install
+
+## Set up the extension for development in the current Python environment
+develop: $(SENTINELS)/develop
+.PHONEY: develop
+
+## Run all tests
+test: $(SENTINELS)/tests-passed
+.PHONY: test
+
+## Install the right version of CKAN into the virtual environment
+ckan-install: $(SENTINELS)/ckan-installed
+	@echo "Current CKAN version: $(shell cat $(SENTINELS)/ckan-version)"
+.PHONY: ckan-install
+
+## Run CKAN in the local virtual environment
+ckan-start: $(SENTINELS)/ckan-installed $(SENTINELS)/install-dev $(CKAN_CONFIG_FILE) | _check_virtualenv
+ifdef CKAN_CLI
+	$(CKAN_CLI) -c $(CKAN_CONFIG_FILE) db init
+	$(CKAN_CLI) -c $(CKAN_CONFIG_FILE) server -r
+else
+	$(PASTER) --plugin=ckan db init -c $(CKAN_CONFIG_FILE)
+	$(PASTER) --plugin=ckan serve --reload --monitor-restart $(CKAN_CONFIG_FILE)
+endif
+.PHONY: ckan-start
+
+$(CKAN_PATH):
+	$(GIT) clone $(CKAN_REPO_URL) $@
+
+$(CKAN_CONFIG_FILE): $(SENTINELS)/ckan-installed $(SENTINELS)/develop | _check_virtualenv
+	$(PASTER) make-config --no-interactive ckan $(CKAN_CONFIG_FILE)
+ifdef CKAN_CLI
+	$(CKAN_CLI) config-tool $(CKAN_CONFIG_FILE) -s DEFAULT debug=true
+	$(CKAN_CLI) config-tool $(CKAN_CONFIG_FILE) $(CKAN_CONFIG_VALUES)
+else
+	$(PASTER) --plugin=ckan config-tool $(CKAN_CONFIG_FILE) -s DEFAULT debug=true
+	$(PASTER) --plugin=ckan config-tool $(CKAN_CONFIG_FILE) $(CKAN_CONFIG_VALUES)
+endif
+
+.env:
+	@___POSTGRES_USER=$(POSTGRES_USER) \
+	___POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) \
+	___POSTGRES_DB=$(POSTGRES_DB) \
+	___CKAN_SOLR_PASSWORD=$(CKAN_SOLR_PASSWORD) \
+	___DATASTORE_DB_NAME=$(DATASTORE_DB_NAME) \
+	___DATASTORE_DB_USER=$(POSTGRES_USER) \
+	___DATASTORE_DB_RO_USER=$(DATASTORE_DB_RO_USER) \
+	___DATASTORE_DB_RO_PASSWORD=$(DATASTORE_DB_RO_PASSWORD) \
+	env | grep ^___ | $(SED) 's/^___//' > .env
+	@cat .env
+
+## Start all Docker services
+docker-up: .env
+	$(DOCKER_COMPOSE) up -d
+	@until $(DOCKER_COMPOSE) exec db pg_isready -U $(POSTGRES_USER); do sleep 1; done
+	@sleep 2
+	@echo " \
+    	CREATE ROLE $(DATASTORE_DB_RO_USER) NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '$(DATASTORE_DB_RO_PASSWORD)'; \
+    	CREATE DATABASE $(DATASTORE_DB_NAME) OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	CREATE DATABASE $(DATASTORE_DB_NAME)_test OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	CREATE DATABASE $(POSTGRES_DB)_test OWNER $(POSTGRES_USER) ENCODING 'utf-8'; \
+    	GRANT ALL PRIVILEGES ON DATABASE $(DATASTORE_DB_NAME) TO $(POSTGRES_USER);  \
+    	GRANT ALL PRIVILEGES ON DATABASE $(DATASTORE_DB_NAME)_test TO $(POSTGRES_USER);  \
+    	GRANT ALL PRIVILEGES ON DATABASE $(POSTGRES_DB)_test TO $(POSTGRES_USER);  \
+    " | $(DOCKER_COMPOSE) exec -T db psql --username "$(POSTGRES_USER)"
+.PHONY: docker-up
+
+## Stop all Docker services
+docker-down: .env
+	$(DOCKER_COMPOSE) down
+.PHONY: docker-down
+
+## Initialize the development environment
+dev-setup: _check_virtualenv $(SENTINELS)/ckan-installed $(CKAN_PATH)/who.ini $(CKAN_CONFIG_FILE) $(SENTINELS)/develop
+.PHONY: setup
+
+## Start a full development environment
+dev-start: dev-setup docker-up ckan-start
+.PHONY: start-dev
+
+## Generate HTML documentation
+html-docs:  # $(SENTINELS)/develop
+	cd docs && make html
+.PHONY: html-docs
+
+# Private targets
+
+_check_virtualenv:
+	@if [ -z "$(VIRTUAL_ENV)" ]; then \
+	  echo "You are not in a virtual environment - activate your virtual environment first"; \
+	  exit 1; \
+	fi
+.PHONY: _check_virtualenv
+
 $(SENTINELS):
 	mkdir -p $@
 
-$(SENTINELS)/test.ini: $(TEST_INI_PATH) $(CKAN_PATH)/test-core.ini | $(SENTINELS)
+$(SENTINELS)/ckan-version: $(CKAN_PATH) | _check_virtualenv $(SENTINELS)
+	$(GIT) -C $(CKAN_PATH) remote update
+	$(GIT) -C $(CKAN_PATH) checkout $(CKAN_VERSION)
+	if [ -e $(CKAN_PATH)/requirement-setuptools.txt ]; then $(PIP) install -r $(CKAN_PATH)/requirement-setuptools.txt; fi
+	if [[ "$(PYTHON_VERSION)" == "2" && -e $(CKAN_PATH)/requirements-py2.txt ]]; then \
+	  $(PIP) install -r $(CKAN_PATH)/requirements-py2.txt; \
+	else \
+	  $(PIP) install -r $(CKAN_PATH)/requirements.txt; \
+	fi
+	$(PIP) install -r $(CKAN_PATH)/dev-requirements.txt
+	$(PIP) install -e $(CKAN_PATH)
+	echo "$(CKAN_VERSION)" > $@
+
+$(SENTINELS)/ckan-installed: $(SENTINELS)/ckan-version | $(SENTINELS)
+	@if [ "$(shell cat $(SENTINELS)/ckan-version)" != "$(CKAN_VERSION)" ]; then \
+	  echo "Switching to CKAN $(CKAN_VERSION)"; \
+	  rm $(SENTINELS)/ckan-version; \
+	  $(MAKE) $(SENTINELS)/ckan-version; \
+	fi
+	@touch $@
+
+$(SENTINELS)/test.ini: $(TEST_INI_PATH) $(CKAN_PATH) $(CKAN_PATH)/test-core.ini | $(SENTINELS)
 	$(SED) "s@use = config:.*@use = config:$(CKAN_PATH)/test-core.ini@" -i $(TEST_INI_PATH)
+ifdef CKAN_CLI
+	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES) $(CKAN_TEST_CONFIG_VALUES)
+else
+	$(PASTER) --plugin=ckan config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES) $(CKAN_TEST_CONFIG_VALUES)
+endif
 	@touch $@
 
 $(SENTINELS)/requirements: requirements.py$(PYTHON_VERSION).txt dev-requirements.py$(PYTHON_VERSION).txt | $(SENTINELS)
@@ -43,9 +207,15 @@ $(SENTINELS)/install: requirements.py$(PYTHON_VERSION).txt | $(SENTINELS)
 	$(PIP) install -r requirements.py$(PYTHON_VERSION).txt
 	@touch $@
 
-$(SENTINELS)/develop: $(SENTINELS)/requirements $(SENTINELS)/install $(SENTINELS)/test.ini setup.py | $(SENTINELS)
+$(SENTINELS)/install-dev: requirements.py$(PYTHON_VERSION).txt | $(SENTINELS)
 	$(PIP) install -r dev-requirements.py$(PYTHON_VERSION).txt
 	$(PIP) install -e .
+	@touch $@
+
+$(SENTINELS)/develop: $(SENTINELS)/requirements $(SENTINELS)/install $(SENTINELS)/install-dev setup.py | $(SENTINELS)
+	@touch $@
+
+$(SENTINELS)/test-setup: $(SENTINELS)/develop $(SENTINELS)/test.ini
 ifdef CKAN_CLI
 	$(CKAN_CLI) -c $(TEST_INI_PATH) db init
 else
@@ -53,8 +223,8 @@ else
 endif
 	@touch $@
 
-$(SENTINELS)/tests-passed: $(SENTINELS)/develop $(shell find $(PACKAGE_DIR) -type f) .flake8 .isort.cfg | $(SENTINELS)
-	$(PYTEST) \
+$(SENTINELS)/tests-passed: $(SENTINELS)/test-setup $(shell find $(PACKAGE_DIR) -type f) .flake8 .isort.cfg | $(SENTINELS)
+	$(PYTEST) $(COVERAGE_ARG) \
 		--flake8 \
 		--isort \
 		--ckan-ini=$(TEST_INI_PATH) \
@@ -62,30 +232,27 @@ $(SENTINELS)/tests-passed: $(SENTINELS)/develop $(shell find $(PACKAGE_DIR) -typ
 		$(PACKAGE_DIR)
 	@touch $@
 
-.coverage: $(SENTINELS)/tests-passed $(shell find $(PACKAGE_DIR) -type f) .coveragerc
-	$(PYTEST) \
-		--flake8 \
-		--isort \
-		--ckan-ini=$(TEST_INI_PATH) \
-		--doctest-modules \
-		--cov=$(PACKAGE_NAME) \
-		$(PACKAGE_DIR)
+# Help related variables and targets
 
-html-docs:  # $(SENTINELS)/develop
-	cd docs && make html
-.PHONY: html-docs
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+TARGET_MAX_CHAR_NUM := 15
 
-install: $(SENTINELS)/install
-.PHONY: install
-
-requirements: $(SENTINELS)/requirements
-.PHONEY: requirements
-
-develop: $(SENTINELS)/develop
-.PHONEY: develop
-
-test: $(SENTINELS)/tests-passed
-.PHONY: test
-
-coverage: .coverage
-.PHONY: coverage
+## Show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+	  helpMessage = match(lastLine, /^## (.*)/); \
+	  if (helpMessage) { \
+	    helpCommand = substr($$1, 0, index($$1, ":")-1); \
+	    helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+	    printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+	  } \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ $(SENTINELS)/ckan-installed: $(SENTINELS)/ckan-version | $(SENTINELS)
 $(SENTINELS)/test.ini: $(TEST_INI_PATH) $(CKAN_PATH) $(CKAN_PATH)/test-core.ini | $(SENTINELS)
 	$(SED) "s@use = config:.*@use = config:$(CKAN_PATH)/test-core.ini@" -i $(TEST_INI_PATH)
 ifdef CKAN_CLI
-	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES) $(CKAN_TEST_CONFIG_VALUES)
+	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES)
+	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $$(CKAN_TEST_CONFIG_VALUES)
 else
 	$(PASTER) --plugin=ckan config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES) $(CKAN_TEST_CONFIG_VALUES)
 endif

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ CKAN_CONFIG_VALUES := \
 CKAN_TEST_CONFIG_VALUES := \
 		sqlalchemy.url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(POSTGRES_DB)_test \
 		ckan.datastore.write_url=postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@localhost/$(DATASTORE_DB_NAME)_test \
-		ckan.datastore.read_url=postgresql://$(DATASTORE_DB_RO_USER):$(DATASTORE_DB_RO_PASSWORD)@localhost/$(DATASTORE_DB_NAME)_test
+		ckan.datastore.read_url=postgresql://$(DATASTORE_DB_RO_USER):$(DATASTORE_DB_RO_PASSWORD)@localhost/$(DATASTORE_DB_NAME)_test \
+		ckanext.authz_service.jwt_algorithm=none \
+		ckanext.authz_service.jwt_private_key=
 
 ifdef WITH_COVERAGE
   COVERAGE_ARG := --cov=$(PACKAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(SENTINELS)/test.ini: $(TEST_INI_PATH) $(CKAN_PATH) $(CKAN_PATH)/test-core.ini 
 	$(SED) "s@use = config:.*@use = config:$(CKAN_PATH)/test-core.ini@" -i $(TEST_INI_PATH)
 ifdef CKAN_CLI
 	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES)
-	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $$(CKAN_TEST_CONFIG_VALUES)
+	$(CKAN_CLI) config-tool $(CKAN_PATH)/test-core.ini $(CKAN_TEST_CONFIG_VALUES)
 else
 	$(PASTER) --plugin=ckan config-tool $(CKAN_PATH)/test-core.ini $(CKAN_CONFIG_VALUES) $(CKAN_TEST_CONFIG_VALUES)
 endif

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -4,20 +4,7 @@ set -e
 echo "This is travis-build.bash..."
 echo "Targetting CKAN $CKANVERSION on Python $TRAVIS_PYTHON_VERSION"
 
-echo "Installing the packages that CKAN requires..."
-sudo apt-get update -qq
-sudo apt-get install solr-jetty
-
 make ckan-install CKAN_VERSION=$CKANVERSION
-
-echo "Setting up Solr..."
-# solr is multicore for tests on ckan master now, but it's easier to run tests
-# on Travis single-core still.
-# see https://github.com/ckan/ckan/issues/2972
-sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
-printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
 
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan WITH PASSWORD 'ckan';"

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -3,48 +3,12 @@ set -e
 
 echo "This is travis-build.bash..."
 echo "Targetting CKAN $CKANVERSION on Python $TRAVIS_PYTHON_VERSION"
-if [ $CKANVERSION == 'master' ]
-then
-    export CKAN_MINOR_VERSION=100
-else
-    export CKAN_MINOR_VERSION=${CKANVERSION##*.}
-fi
-
-export PYTHON_MAJOR_VERSION=${TRAVIS_PYTHON_VERSION%.*}
-
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
 sudo apt-get install solr-jetty
 
-echo "Installing CKAN and its Python dependencies..."
-git clone https://github.com/ckan/ckan
-cd ckan
-if [ $CKANVERSION == 'master' ]
-then
-    echo "CKAN version: master"
-else
-    CKAN_TAG=$(git tag | grep ^ckan-$CKANVERSION | sort --version-sort | tail -n 1)
-    git checkout $CKAN_TAG
-    echo "CKAN version: ${CKAN_TAG#ckan-}"
-fi
-
-if [ -e requirement-setuptools.txt ]
-then
-    pip install -r requirement-setuptools.txt
-fi
-
-python setup.py develop
-
-if [[ "$PYTHON_MAJOR_VERSION" == "2" && -e requirements-py2.txt ]]
-then
-    pip install -r requirements-py2.txt
-else
-    pip install -r requirements.txt
-fi
-
-pip install -r dev-requirements.txt
-cd -
+make ckan-install CKAN_VERSION=$CKANVERSION
 
 echo "Setting up Solr..."
 # solr is multicore for tests on ckan master now, but it's easier to run tests
@@ -56,12 +20,9 @@ sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
 
 echo "Creating the PostgreSQL user and database..."
-sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
-sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
-sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
-sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default;'
-
-echo "Setting the environment for ckanext-authz-service testing..."
-make develop CKAN_PATH=./ckan
+sudo -u postgres psql -c "CREATE USER ckan WITH PASSWORD 'ckan';"
+sudo -u postgres psql -c "CREATE USER datastore_ro WITH PASSWORD 'datastore_ro';"
+sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan;'
+sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan;'
 
 echo "travis-build.bash is done."

--- a/ckanext/authz_service/authz_binding/__init__.py
+++ b/ckanext/authz_service/authz_binding/__init__.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional, Set
+
 from ..authzzie import Authzzie
 from . import dataset as ds
 from . import organization as org
@@ -14,16 +16,25 @@ def default_authz_bindings(authorizer):
     # Register organization authz bindings
     authorizer.register_scope_normalizer('org', org.normalize_org_scope)
     authorizer.register_authorizer('org', org.check_org_permissions,
-                                   actions=org.ORG_ENTITY_CHECKS.keys() + [None])
+                                   actions=_all_entity_actions(org.ORG_ENTITY_CHECKS))
 
     # Register dataset authz bindings
     authorizer.register_entity_ref_parser('ds', ds.dataset_id_parser)
     authorizer.register_authorizer('ds', ds.check_dataset_permissions,
-                                   actions=ds.DS_ENTITY_CHECKS.keys() + [None],
+                                   actions=_all_entity_actions(ds.DS_ENTITY_CHECKS),
                                    subscopes=(None, 'data', 'metadata'))
 
     # Register resource authz bindings
     authorizer.register_entity_ref_parser('res', res.resource_id_parser)
     authorizer.register_authorizer('res', res.check_resource_permissions,
-                                   actions=res.RES_ENTITY_CHECKS.keys() + [None],
+                                   actions=_all_entity_actions(res.RES_ENTITY_CHECKS),
                                    subscopes=(None, 'data', 'metadata'))
+
+
+def _all_entity_actions(entity_checks):
+    # type: (Dict[str, Optional[str]]) -> Set[Optional[str]]
+    """Get a set of all entity actions
+    """
+    actions = set(entity_checks.keys())
+    actions.add(None)
+    return actions

--- a/ckanext/authz_service/tests/__init__.py
+++ b/ckanext/authz_service/tests/__init__.py
@@ -2,13 +2,7 @@ from contextlib import contextmanager
 from typing import Any, Dict
 
 from ckan import model
-from ckan.tests import helpers
 from mock import patch
-
-
-class FunctionalTestBase(helpers.FunctionalTestBase):
-
-    _load_plugins = ['authz_service']
 
 
 @contextmanager

--- a/ckanext/authz_service/tests/test_actions.py
+++ b/ckanext/authz_service/tests/test_actions.py
@@ -2,8 +2,9 @@ import jwt
 import pytest
 from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
+from ckan.tests.helpers import FunctionalTestBase
 
-from . import FunctionalTestBase, temporary_file, user_context
+from . import temporary_file, user_context
 
 # RSA public key for testing purposes
 RSA_PUB_KEY = """

--- a/ckanext/authz_service/tests/test_authorization.py
+++ b/ckanext/authz_service/tests/test_authorization.py
@@ -3,10 +3,10 @@ from ckan.tests import factories, helpers
 from ckanext.authz_service.authzzie import Scope
 from ckanext.authz_service.plugin import init_authorizer
 
-from . import FunctionalTestBase, user_context
+from . import user_context
 
 
-class TestDatasetAuthBinding(FunctionalTestBase):
+class TestDatasetAuthBinding(helpers.FunctionalTestBase):
     """Test cases for the default authorization binding defined in the extension
     for datasets
     """
@@ -84,7 +84,7 @@ class TestDatasetAuthBinding(FunctionalTestBase):
         assert granted == {'create', 'list'}
 
 
-class TestResourceAuthBinding(FunctionalTestBase):
+class TestResourceAuthBinding(helpers.FunctionalTestBase):
     """Test cases for the default authorization binding defined in the extension
     for resources
     """
@@ -151,7 +151,7 @@ class TestResourceAuthBinding(FunctionalTestBase):
         assert granted == set()
 
 
-class TestOrganizationAuthBinding(FunctionalTestBase):
+class TestOrganizationAuthBinding(helpers.FunctionalTestBase):
     """Test cases for the default authorization binding defined in the extension
     for resources
     """

--- a/ckanext/authz_service/tests/test_authzzie.py
+++ b/ckanext/authz_service/tests/test_authzzie.py
@@ -1,7 +1,6 @@
 """Tests for the Authzzie permission mapping library
 """
 import pytest
-from nose.tools import assert_equals
 from six import iteritems
 
 from ckanext.authz_service import authzzie
@@ -92,7 +91,7 @@ def test_action_aliases():
 
     scope = authzzie.Scope('foo', 'entity-01', {'look-at-things'})
     granted = az.authorize_scope(scope)
-    assert_equals(str(granted), 'foo:entity-01:look-at-things')
+    assert 'foo:entity-01:look-at-things' == str(granted)
 
 
 def test_action_aliases_with_type_alias():
@@ -107,4 +106,4 @@ def test_action_aliases_with_type_alias():
 
     scope = authzzie.Scope('bar', 'entity-01', {'look-at-things'})
     granted = az.authorize_scope(scope)
-    assert_equals(str(granted), 'bar:entity-01:look-at-things')
+    assert 'bar:entity-01:look-at-things' == str(granted)

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,8 +1,8 @@
 pip-tools==4.5.*
 pytest==4.6.*
+pytest-ckan==0.0.*
 pytest-cov==2.8.*
 pytest-flake8==1.0.*
 pytest-isort==0.3.*
 coveralls==1.8.*
 sphinx-autodoc-typehints[type_comments]==1.10.*; python_version >= '3.5'
-git+https://github.com/datopian/pytest-ckan#egg=pytest-ckan

--- a/dev-requirements.py2.txt
+++ b/dev-requirements.py2.txt
@@ -39,7 +39,7 @@ pycparser==2.20           # via cffi
 pyflakes==2.1.1           # via flake8
 pyopenssl==19.1.0         # via urllib3
 pyparsing==2.4.7          # via packaging
-git+https://github.com/datopian/pytest-ckan#egg=pytest-ckan  # via -r dev-requirements.in
+pytest-ckan==0.0.12       # via -r dev-requirements.in
 pytest-cov==2.8.1         # via -r dev-requirements.in
 pytest-flake8==1.0.5      # via -r dev-requirements.in
 pytest-isort==0.3.1       # via -r dev-requirements.in

--- a/dev-requirements.py3.txt
+++ b/dev-requirements.py3.txt
@@ -33,7 +33,7 @@ pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
-git+https://github.com/datopian/pytest-ckan#egg=pytest-ckan  # via -r dev-requirements.in
+pytest-ckan==0.0.12       # via -r dev-requirements.in
 pytest-cov==2.8.1         # via -r dev-requirements.in
 pytest-flake8==1.0.5      # via -r dev-requirements.in
 pytest-isort==0.3.1       # via -r dev-requirements.in

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.1.1',
+    version='0.1.2',
 
     description='''Add CKAN API to generate JWT tokens with authorization information''',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='''ckanext-authz-service''',
+    name='ckanext-authz-service',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
@@ -25,8 +25,8 @@ setup(
     url='https://github.com/datopian/ckanext-authz-service',
 
     # Author details
-    author='''Shahar Evron''',
-    author_email='''shahar.evron@datopian.com''',
+    author='Shahar Evron',
+    author_email='shahar.evron@datopian.com',
 
     # Choose your license
     license='MIT',
@@ -50,7 +50,7 @@ setup(
 
 
     # What does your project relate to?
-    keywords='''CKAN authorization jwt authz microservices integration''',
+    keywords='CKAN authorization jwt authz microservices integration',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().

--- a/test.ini
+++ b/test.ini
@@ -11,11 +11,6 @@ port = 5000
 [app:main]
 use = config:ckan/test-core.ini
 
-# ckanext-authz-service settings for testing purposes
-# NOTE: NEVER copy these settings to a production environment, they are not secure
-
-ckanext.authz_service.jwt_algorithm = none
-
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:ckan/test-core.ini
 
 # ckanext-authz-service settings for testing purposes
 # NOTE: NEVER copy these settings to a production environment, they are not secure


### PR DESCRIPTION
- Migrate all tests to use pytest
- Some tests are still failing with CKAN master, but it is working better than with nose.test
- Many improvements to Makefile and CI scripts
- Some fixes to the code for Python 3.6 that were detected now that *some* tests actually run