### PR TITLE
Implement route to download public key with no JSON wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ services:
   - redis
   - docker
 
-# use an older trusty image, because the newer images cause build errors with
-# psycopg2 that comes with CKAN<2.8:
-#   "Error: could not determine PostgreSQL version from '10.1'"
-# see https://github.com/travis-ci/travis-ci/issues/8897
-#dist: trusty
-#group: deprecated-2017Q4
-
 python:
   - 2.7
   - 3.6

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ having it pre-configured.
 }
 ```
 
+### Downloading the Public Key via direct URL
+The public key, if configured, is also available to download directly by clients
+at:
+
+    https://your.ckan.installation/authz/public_key
+
+Sending a GET request to this URL will let you download the key in PEM format without
+the JSON response wrapper of the CKAN API. This may be more convenient in most cases. 
+
+If no public key is configured (e.g. CKAN is using a symmetric algorithm to sign JWT
+tokens), hitting this URL should return an `HTTP 204` response with no content.  
+
 Authorization Scopes
 --------------------
 "Scopes" in the context of `authz-service` represent permission to perform one

--- a/ckanext/authz_service/blueprints.py
+++ b/ckanext/authz_service/blueprints.py
@@ -1,0 +1,29 @@
+"""ckanext-authz-service Flask blueprints
+"""
+from ckan.plugins import toolkit
+from flask import Blueprint, Response
+
+blueprint = Blueprint(
+    'authz_service',
+    __name__,
+)
+
+
+def public_key():
+    """Get the public key used to verify JWT tokens signed by us
+
+    If no public key has been configured (e.g. we are using a symmetric algorithm), will
+    return 204 with no content.
+    """
+    try:
+        pub_key = toolkit.get_action('authz_public_key')(None, {}).get('public_key')
+    except (toolkit.ObjectNotFound, AttributeError, KeyError):
+        pub_key = None
+
+    if not pub_key:
+        return '', 204, {"Content-type": None}
+
+    return Response(pub_key, mimetype='application/x-pem-file')
+
+
+blueprint.add_url_rule(u'/authz/public_key', view_func=public_key)

--- a/ckanext/authz_service/plugin.py
+++ b/ckanext/authz_service/plugin.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import ckan.plugins as plugins
 
-from ckanext.authz_service import actions
+from ckanext.authz_service import actions, blueprints
 from ckanext.authz_service.authz_binding import default_authz_bindings
 from ckanext.authz_service.authzzie import Authzzie
 from ckanext.authz_service.interfaces import IAuthorizationBindings
@@ -10,6 +10,7 @@ from ckanext.authz_service.interfaces import IAuthorizationBindings
 
 class AuthzServicePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IBlueprint)
     plugins.implements(IAuthorizationBindings)
 
     # IActions
@@ -19,6 +20,12 @@ class AuthzServicePlugin(plugins.SingletonPlugin):
         return {'authz_authorize': partial(actions.authorize, authorizer),
                 'authz_verify': actions.verify,
                 'authz_public_key': actions.public_key}
+
+    # IBlueprint
+    def get_blueprint(self):
+        return blueprints.blueprint
+
+    # IAuthorizationBindings
 
     def register_authz_bindings(self, authorizer):
         default_authz_bindings(authorizer)

--- a/ckanext/authz_service/tests/test_actions.py
+++ b/ckanext/authz_service/tests/test_actions.py
@@ -7,22 +7,20 @@ from ckan.tests.helpers import FunctionalTestBase
 from . import temporary_file, user_context
 
 # RSA public key for testing purposes
-RSA_PUB_KEY = """
------BEGIN PUBLIC KEY-----
-MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwa1W4fb4CgFH5EXsLlJI
-Vr+r2ZB17hR4mXNhJhj4hXm4UQlC6Rnjc1MJ1fse3ClkaD5GFbGfwnDr2iXMaoBo
-v2F1mZR4TG/5muIEUEwUg2t5z/CBfYMIGG3Fucg9Et2rmc2MQPCPnN5H8XvzCgE4
-Wa662tMtGZmM1FtKtMVEM3MRo4rHNS4wcl+SPoKLgAOgWQtIMVy0AYyldRfBVG3+
-vrB4Y++leN8DZZrLYALL93WmMiaZE9Al8rndTte5gIaLJ2cnHXL8KEw6JPBXwP92
-QEIzFlh0Nbt0FSRnX9wrJovJikTeMWD75zevGP5I4Oag0oiARVh5iZHNsEYki2dC
-XOX01Eqh2ZXwuqOUon5RAaJesdbGz5M6G1zY5CTZ7tzgiDkl1vl0PC12J8XmfTda
-pg8OxHi9EI8caqIqATaExSMFSFs+OxEog8vv+DifQfVzCxyGiOkw81NRPw46Qylf
-UBaeSYhylc2KRLuMRfVLT5HMLzG7QJ0jinkaUKGJznCzEqynxa187Ar1Z+SDZ07g
-q54mfdM9B6eS/SEbJhFI9oRFv9BSlo8YXfzLHOdXwrmWZDZmzTKfAtQKY9luSfrL
-8Fe0+w4kGtQ5PLXEe7NWCSS9oXnVAs7/cNxqaKNHF8gj39iBvJdyVdqsMHtXdyvz
-ZK4b9J6UQSKjmNaLu8EuVi8CAwEAAQ==
------END PUBLIC KEY-----
-"""
+RSA_PUB_KEY = ("-----BEGIN PUBLIC KEY-----\n"
+               "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwa1W4fb4CgFH5EXsLlJI\n"
+               "Vr+r2ZB17hR4mXNhJhj4hXm4UQlC6Rnjc1MJ1fse3ClkaD5GFbGfwnDr2iXMaoBo\n"
+               "v2F1mZR4TG/5muIEUEwUg2t5z/CBfYMIGG3Fucg9Et2rmc2MQPCPnN5H8XvzCgE4\n"
+               "Wa662tMtGZmM1FtKtMVEM3MRo4rHNS4wcl+SPoKLgAOgWQtIMVy0AYyldRfBVG3+\n"
+               "vrB4Y++leN8DZZrLYALL93WmMiaZE9Al8rndTte5gIaLJ2cnHXL8KEw6JPBXwP92\n"
+               "QEIzFlh0Nbt0FSRnX9wrJovJikTeMWD75zevGP5I4Oag0oiARVh5iZHNsEYki2dC\n"
+               "XOX01Eqh2ZXwuqOUon5RAaJesdbGz5M6G1zY5CTZ7tzgiDkl1vl0PC12J8XmfTda\n"
+               "pg8OxHi9EI8caqIqATaExSMFSFs+OxEog8vv+DifQfVzCxyGiOkw81NRPw46Qylf\n"
+               "UBaeSYhylc2KRLuMRfVLT5HMLzG7QJ0jinkaUKGJznCzEqynxa187Ar1Z+SDZ07g\n"
+               "q54mfdM9B6eS/SEbJhFI9oRFv9BSlo8YXfzLHOdXwrmWZDZmzTKfAtQKY9luSfrL\n"
+               "8Fe0+w4kGtQ5PLXEe7NWCSS9oXnVAs7/cNxqaKNHF8gj39iBvJdyVdqsMHtXdyvz\n"
+               "ZK4b9J6UQSKjmNaLu8EuVi8CAwEAAQ==\n"
+               "-----END PUBLIC KEY-----")
 
 
 class TestAuthorizeAction(FunctionalTestBase):

--- a/ckanext/authz_service/tests/test_functional.py
+++ b/ckanext/authz_service/tests/test_functional.py
@@ -1,0 +1,27 @@
+"""Functional tests relying on the full CKAN app stack
+
+This is mainly for testing blueprints
+"""
+from ckan.plugins import toolkit
+from ckan.tests import helpers
+
+from . import temporary_file
+from .test_actions import RSA_PUB_KEY
+
+
+def test_get_public_key(app):
+    url = toolkit.url_for('authz_service.public_key')
+    with temporary_file(RSA_PUB_KEY) as pub_key_file, \
+            helpers.changed_config('ckanext.authz_service.jwt_public_key_file', pub_key_file):
+        response = app.get(url)
+
+    assert response.status_int == 200
+    assert response.headers['content-type'] == 'application/x-pem-file'
+    assert response.body == RSA_PUB_KEY
+
+
+def test_get_public_key_no_key_configured(app):
+    url = toolkit.url_for('authz_service.public_key')
+    response = app.get(url)
+    assert response.status_int == 204
+    assert not response.body

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Docker Compose file for ckanext-asset-storage
+# ------------------------------------------------
+# The purpose of this docker-compose file is to simplify setting up a
+# development environment for this CKAN extension; It defines Docker based
+# services for all external CKAN dependencies (DB, Solr, Redis) but not for
+# CKAN itself - you should probably run CKAN in a local virtual environment
+# to simplify debugging.
+#
+# Most likely, you do not want to use this file directly with `docker-compose`
+# but use the provided Make targets to manage things.
+
+version: "3"
+
+volumes:
+  db_data:
+
+services:
+
+  db:
+    image: postgres:9-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  solr:
+    image: ckan/solr
+    environment:
+      - CKAN_SOLR_PASSWORD=${CKAN_SOLR_PASSWORD}
+    ports:
+      - 8983:8983
+
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379


### PR DESCRIPTION
This implements #5 with one small change: if no key is configured, we return 204 (No Content) and not 404 as specified in the ticket. This is because we want to differentiate between the route not being available at all (e.g. the extension is not enabled) and between a "normal" situation in which the client should not get an error but just know that there is no key to download.