### PR TITLE
Add support for anonymous users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ docs/_build/
 
 # Development environment
 /ckan/
+/.env

--- a/ckanext/authz_service/authz_binding/organization.py
+++ b/ckanext/authz_service/authz_binding/organization.py
@@ -1,6 +1,6 @@
 """Authorization bindings for organizations
 """
-from typing import Optional, Set
+from typing import Set
 
 from ..authzzie import Scope
 from .common import check_entity_permissions, ckan_auth_check, ckan_is_sysadmin
@@ -15,7 +15,7 @@ ORG_ENTITY_CHECKS = {"read": "organization_show",
 
 
 def check_org_permissions(id):
-    # type: (str, Optional[str]) -> Set[str]
+    # type: (str) -> Set[str]
     """Check what org permissions a user has
     """
     if ckan_is_sysadmin():
@@ -33,7 +33,6 @@ def check_org_permissions(id):
 
         if ckan_auth_check('organization_create'):
             granted.add('create')
-
     else:
         granted.update(check_entity_permissions(ORG_ENTITY_CHECKS, {"id": id}))
 

--- a/ckanext/authz_service/tests/__init__.py
+++ b/ckanext/authz_service/tests/__init__.py
@@ -8,13 +8,14 @@ ANONYMOUS_USER = None
 
 
 @contextmanager
-def user_context(user):
-    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
+def user_context(user, ignore_auth=False):
+    # type: (Optional[Dict[str, Any]], bool) -> Dict[str, Any]
     """Context manager that creates a CKAN context dict for a user, then
     both patches our `get_user_context` function to return it and also
     yields the context for use inside tests
     """
     context = {"model": model,
+               "ignore_auth": ignore_auth,
                "user": None,
                "auth_user_obj": None,
                "userobj": None}

--- a/ckanext/authz_service/tests/__init__.py
+++ b/ckanext/authz_service/tests/__init__.py
@@ -1,27 +1,31 @@
 from contextlib import contextmanager
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ckan import model
 from mock import patch
 
+ANONYMOUS_USER = None
+
 
 @contextmanager
 def user_context(user):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
+    # type: (Optional[Dict[str, Any]]) -> Dict[str, Any]
     """Context manager that creates a CKAN context dict for a user, then
     both patches our `get_user_context` function to return it and also
     yields the context for use inside tests
     """
-    userobj = model.User.get(user['name'])
     context = {"model": model,
-               "user": user['name'],
-               "auth_user_obj": userobj,
-               "userobj": userobj}
+               "user": None,
+               "auth_user_obj": None,
+               "userobj": None}
 
-    def mock_context():
-        return context
+    if user is not ANONYMOUS_USER:
+        userobj = model.User.get(user['name'])
+        context.update({"user": user['name'],
+                        "auth_user_obj": userobj,
+                        "userobj": userobj})
 
-    with patch('ckanext.authz_service.authz_binding.common.get_user_context', mock_context):
+    with patch('ckanext.authz_service.authz_binding.common.get_user_context', lambda: context):
         yield context
 
 


### PR DESCRIPTION
This PR fixes an issue with anonymous CKAN users (not logged in). Most CKAN installation will allow *some* permissions to anonymous users (such as reading public datasets). But this extension was never built to support it until now. 

Resolves #15 