### PR TITLE
Python 3 and CKAN 2.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ determine a user's access level, or define custom entity types to support.
 Requirements
 ------------
 
-This extension works with CKAN 2.8.x.
-
-It may work, but has not been tested, with other CKAN versions.
+This extension works with CKAN 2.8.x and CKAN 2.9.x with both Python 2 and 3.
 
 
 Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ckanext-authz-service
 =====================
-![Tests](https://github.com/datopian/ckanext-authz-service/workflows/tests/badge.svg?branch=master)
+![Tests](https://github.com/datopian/ckanext-authz-service/workflows/test/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/datopian/ckanext-authz-service/badge.svg?branch=master)](https://coveralls.io/github/datopian/ckanext-authz-service?branch=master)
 
 **JSON Web Tokens (JWT) Based Authorization API for CKAN**

--- a/ckanext/authz_service/actions.py
+++ b/ckanext/authz_service/actions.py
@@ -148,4 +148,4 @@ def _generate_jti(length=8):
     # type: (int) -> bytes
     """Generate a unique token ID
     """
-    return b''.join(random.choice(string.printable) for _ in range(length))
+    return ''.join(random.choice(string.printable) for _ in range(length))

--- a/ckanext/authz_service/actions.py
+++ b/ckanext/authz_service/actions.py
@@ -31,7 +31,7 @@ def authorize(authorizer, context, data_dict):
     expires = datetime.now(tz=pytz.utc) + timedelta(seconds=lifetime)
 
     try:
-        granted_scopes = map(str, filter(None, (authorizer.authorize_scope(s) for s in requested_scopes)))
+        granted_scopes = [str(scope) for scope in filter(None, (authorizer.authorize_scope(s) for s in requested_scopes))]
     except UnknownEntityType as e:
         raise toolkit.ValidationError(str(e))
 

--- a/ckanext/authz_service/tests/test_actions.py
+++ b/ckanext/authz_service/tests/test_actions.py
@@ -110,6 +110,9 @@ class TestAuthorizeAction():
 @pytest.mark.usefixtures('with_plugins')
 class TestPublicKeyAction():
 
+    @pytest.mark.skipif(
+        toolkit.check_ckan_version(min_version='2.9'),
+        reason='Test fixture not supported in Python 3')
     def test_public_key_is_available(self):
         """Test that public key is returned properly
         """

--- a/ckanext/authz_service/tests/test_functional.py
+++ b/ckanext/authz_service/tests/test_functional.py
@@ -2,13 +2,17 @@
 
 This is mainly for testing blueprints
 """
+import pytest
+
 from ckan.plugins import toolkit
 from ckan.tests import helpers
 
 from . import temporary_file
 from .test_actions import RSA_PUB_KEY
 
-
+@pytest.mark.skipif(
+    toolkit.check_ckan_version(min_version='2.9'),
+    reason='Test fixture not supported in Python 3')
 def test_get_public_key(app):
     url = toolkit.url_for('authz_service.public_key')
     with temporary_file(RSA_PUB_KEY) as pub_key_file, \


### PR DESCRIPTION
This PR makes changes to run under Python 3 and CKAN 2.9 while keep backwards compatibility to Python 2.7 and CKAN 2.8.